### PR TITLE
Show correct join order

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "rimraf dist && tsc",
     "test": "yarn run lint",
     "lint": "eslint \"src/**/*.{js,ts}\" --ignore-path .gitignore",
-    "migration:generate": "TS_NODE=true ts-node ./node_modules/.bin/typeorm migration:generate"
+    "migration:generate": "TS_NODE=true ts-node ./node_modules/.bin/typeorm migration:generate",
+    "migration:run": "TS_NODE=true ts-node ./node_modules/.bin/typeorm migration:run"
   },
   "author": "sct",
   "license": "MIT",

--- a/src/actions/create.ts
+++ b/src/actions/create.ts
@@ -3,20 +3,6 @@ import { Player } from '../entity/Player';
 import { Event } from '../entity/Event';
 import logger from '../logger';
 
-const numberToEmoji = {
-  0: '0️⃣',
-  1: '1️⃣',
-  2: '2️⃣',
-  3: '3️⃣',
-  4: '4️⃣',
-  5: '5️⃣',
-  6: '6️⃣',
-  7: '7️⃣',
-  8: '8️⃣',
-  9: '9️⃣',
-  10: '🔟',
-};
-
 export enum EVENT_RESULT {
   CREATED,
   MAX,
@@ -55,14 +41,11 @@ export const createEvent = async ({
   }
 
   const guildEventCount = await eventRepository.count({ where: guildId });
-  const newEventNumber = guildEventCount as keyof typeof numberToEmoji;
 
-  if (newEventNumber <= 10) {
-    const emoji = numberToEmoji[newEventNumber];
+  if (guildEventCount <= 10) {
     const newEvent = new Event({
       guildId,
       name,
-      emoji,
       rank: 'iron1',
       owner: player,
       players: [player],

--- a/src/actions/join.ts
+++ b/src/actions/join.ts
@@ -39,13 +39,12 @@ export enum JOIN_RESULT {
 }
 
 export const joinEvent = async ({
-  guildId,
   discordId,
-  emoji,
+  event,
 }: {
   guildId: string;
   discordId: string;
-  emoji: string;
+  event: Event;
 }): Promise<JOIN_RESULT> => {
   const playerRepository = getRepository(Player);
   const eventRepository = getRepository(Event);
@@ -57,11 +56,6 @@ export const joinEvent = async ({
   if (!player) {
     throw new Error('Player data not found when trying to join event');
   }
-
-  const event = await eventRepository.findOne({
-    where: { emoji, guildId },
-    relations: ['players'],
-  });
 
   if (!event) {
     logger.info('Event does not exist');

--- a/src/actions/leave.ts
+++ b/src/actions/leave.ts
@@ -43,12 +43,11 @@ export const leaveEvent = async ({
         msg: `**${player.joinedEvent.name}** has been removed`,
       };
     } else {
-      const newOwner = player.joinedEvent.players.find(
-        (p) => p.id !== player.id
+      const sortedPlayers = player.joinedEvent.players.sort(
+        (a, b) => a.updatedAt.getTime() - b.updatedAt.getTime()
       );
-      const newPlayers = player.joinedEvent.players.filter(
-        (p) => p.id !== player.id
-      );
+      const newOwner = sortedPlayers.find((p) => p.id !== player.id);
+      const newPlayers = sortedPlayers.filter((p) => p.id !== player.id);
 
       if (!newOwner || newPlayers.length === 0) {
         await eventRepository.delete(player.joinedEvent.id);
@@ -59,6 +58,8 @@ export const leaveEvent = async ({
       }
       player.joinedEvent.players = newPlayers;
       player.joinedEvent.owner = newOwner;
+
+      await eventRepository.save(player.joinedEvent);
 
       let msg = `**${player.name}** has left event: **${player.joinedEvent.name}**.\n`;
       msg += `Ownership transferred to: **${newOwner.name}**`;

--- a/src/actions/report.ts
+++ b/src/actions/report.ts
@@ -18,7 +18,7 @@ export const getEventsDetails = async ({
   const guild = await guildRepository.findOne({ guildId });
   const events = await eventRepository.find({
     where: { guildId },
-    relations: ['players'],
+    relations: ['players', 'owner'],
   });
 
   const embed = createEmbed(events);

--- a/src/bot/BotController.ts
+++ b/src/bot/BotController.ts
@@ -16,7 +16,12 @@ export class BotController {
       .registerDefaultTypes()
       .registerGroups([['general', 'General Commands']])
       .registerDefaultGroups()
-      .registerDefaultCommands()
+      .registerDefaultCommands({
+        eval: false,
+        commandState: false,
+        ping: false,
+        prefix: false,
+      })
       .registerCommands(Commands);
 
     this.client.login(config.general.botToken);
@@ -50,5 +55,7 @@ export class BotController {
     });
   };
 }
+
+export const bot = new BotController();
 
 export default BotController;

--- a/src/entity/Event.ts
+++ b/src/entity/Event.ts
@@ -17,9 +17,6 @@ export class Event {
   public name: string;
 
   @Column()
-  public emoji: string;
-
-  @Column()
   public guildId: string;
 
   @Column()

--- a/src/entity/Player.ts
+++ b/src/entity/Player.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Event } from './Event';
 
 @Entity()
@@ -14,6 +21,12 @@ export class Player {
 
   @ManyToOne(() => Event, (event) => event.players, { onDelete: 'SET NULL' })
   public joinedEvent: Event;
+
+  @CreateDateColumn()
+  public createdAt: Date;
+
+  @UpdateDateColumn()
+  public updatedAt: Date;
 
   constructor(init?: Partial<Player>) {
     Object.assign(this, init);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import { createConnection } from 'typeorm';
-import BotController from './bot/BotController';
+import { bot } from './bot/BotController';
 
 // Setup Discord Bot
-const bot = new BotController();
 bot.connect();
 
 // Setup DB connection

--- a/src/migration/1594030518051-RemoveEmojiAndAddUpdatedForPlayers.ts
+++ b/src/migration/1594030518051-RemoveEmojiAndAddUpdatedForPlayers.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveEmojiAndAddUpdatedForPlayers1594030518051
+  implements MigrationInterface {
+  name = 'RemoveEmojiAndAddUpdatedForPlayers1594030518051';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_event" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "guildId" varchar NOT NULL, "rank" varchar NOT NULL, "ownerId" integer, CONSTRAINT "UQ_e4abcb418e46db776e920a05a16" UNIQUE ("ownerId"), CONSTRAINT "FK_e4abcb418e46db776e920a05a16" FOREIGN KEY ("ownerId") REFERENCES "player" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_event"("id", "name", "guildId", "rank", "ownerId") SELECT "id", "name", "guildId", "rank", "ownerId" FROM "event"`
+    );
+    await queryRunner.query(`DROP TABLE "event"`);
+    await queryRunner.query(`ALTER TABLE "temporary_event" RENAME TO "event"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_player" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "discordId" text NOT NULL, "rank" varchar NOT NULL, "joinedEventId" integer, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), CONSTRAINT "FK_7bf2513ceb0d6be0512aec1a40e" FOREIGN KEY ("joinedEventId") REFERENCES "event" ("id") ON DELETE SET NULL ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_player"("id", "name", "discordId", "rank", "joinedEventId") SELECT "id", "name", "discordId", "rank", "joinedEventId" FROM "player"`
+    );
+    await queryRunner.query(`DROP TABLE "player"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_player" RENAME TO "player"`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "player" RENAME TO "temporary_player"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "player" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "discordId" text NOT NULL, "rank" varchar NOT NULL, "joinedEventId" integer, CONSTRAINT "FK_7bf2513ceb0d6be0512aec1a40e" FOREIGN KEY ("joinedEventId") REFERENCES "event" ("id") ON DELETE SET NULL ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "player"("id", "name", "discordId", "rank", "joinedEventId") SELECT "id", "name", "discordId", "rank", "joinedEventId" FROM "temporary_player"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_player"`);
+    await queryRunner.query(`ALTER TABLE "event" RENAME TO "temporary_event"`);
+    await queryRunner.query(
+      `CREATE TABLE "event" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "emoji" varchar NOT NULL, "guildId" varchar NOT NULL, "rank" varchar NOT NULL, "ownerId" integer, CONSTRAINT "UQ_e4abcb418e46db776e920a05a16" UNIQUE ("ownerId"), CONSTRAINT "FK_e4abcb418e46db776e920a05a16" FOREIGN KEY ("ownerId") REFERENCES "player" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "event"("id", "name", "guildId", "rank", "ownerId") SELECT "id", "name", "guildId", "rank", "ownerId" FROM "temporary_event"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_event"`);
+  }
+}

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,0 +1,24 @@
+export const numberToEmoji = [
+  '0️⃣',
+  '1️⃣',
+  '2️⃣',
+  '3️⃣',
+  '4️⃣',
+  '5️⃣',
+  '6️⃣',
+  '7️⃣',
+  '8️⃣',
+  '9️⃣',
+  '🔟',
+];
+
+export const getNumberEmoji = (number: number): string => {
+  if (number < 0 || number > numberToEmoji.length) {
+    return 'Unknown';
+  }
+  return numberToEmoji[number];
+};
+
+export const getIndexFromEmoji = (emoji: string): number => {
+  return numberToEmoji.findIndex((e) => e === emoji);
+};

--- a/src/utils/playerUtils.ts
+++ b/src/utils/playerUtils.ts
@@ -1,0 +1,9 @@
+import { bot } from '../bot/BotController';
+
+export const getPlayerName = (serverId: string, playerId: string): string => {
+  const guild = bot.client.guilds.cache.get(serverId);
+
+  const user = guild?.members.cache.get(playerId);
+
+  return user?.displayName ?? 'Unknown User';
+};


### PR DESCRIPTION
- Sorts players by newly created updateAt field on the player table. (Doesn't sort in the query, sorts after in javascript)
- Removes emoji field and instead just uses the emojis and index reference
- BotController now initializes itself and exports its instance so we can use the client in utilities
- Embed shows a different message when there are no events
- Join command now takes the group name instead of an emoji